### PR TITLE
Upload all compiled JARs to artifact

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Upload JAR
         uses: actions/upload-artifact@v4
         with:
-          name: app-jar
-          path: build/libs/*.jar 
+          name: all-jars
+          path: **/build/libs/*.jar 


### PR DESCRIPTION
Upload all compiled JARs to artifact to enable download from GitHub actions