### PR TITLE
Add fix for CVE-2025-22228

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -611,6 +611,16 @@ public class BCrypt {
 		int rounds, off;
 		StringBuilder rs = new StringBuilder();
 
+		if (passwordb.length > 72) {
+			if (!for_check) {
+				throw new IllegalArgumentException(
+						"Password too long: New passwords must not exceed 72 characters, as only the first 72 characters are securely hashed. Please choose a shorter password.");
+			}
+			else {
+				throw new IllegalArgumentException(
+						"Password rejected: This password exceeds 72 characters. While it may be correct, we cannot verify it securely due to limitations in the previous hashing method. Please reset your password to ensure continued account security.");
+			}
+		}
 		if (salt == null) {
 			throw new IllegalArgumentException("salt cannot be null");
 		}

--- a/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
@@ -222,4 +222,35 @@ public class BCryptPasswordEncoderTests {
 		assertThat(encoder.matches("wrong", "$2a$00$9N8N35BVs5TLqGL3pspAte5OWWA2a2aZIs.EGp7At7txYakFERMue")).isFalse();
 	}
 
+	@Test
+	public void encodeWhenPasswordOverMaxLengthThenThrowIllegalArgumentException() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+		String password72chars = "123456789012345678901234567890123456789012345678901234567890123456789012";
+		encoder.encode(password72chars);
+
+		String password73chars = password72chars + "3";
+		assertThatIllegalArgumentException().isThrownBy(() -> encoder.encode(password73chars));
+	}
+
+	@Test
+	public void matchesWhenPasswordOverMaxLengthThenAllowToMatch() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+		String password71chars = "12345678901234567890123456789012345678901234567890123456789012345678901";
+		String encodedPassword71chars = "$2a$10$jx3x2FaF.iX5QZ9i3O424Os2Ou5P5JrnedmWYHuDyX8JKA4Unp4xq";
+		assertThat(encoder.matches(password71chars, encodedPassword71chars)).isTrue();
+
+		String password72chars = password71chars + "2";
+		String encodedPassword72chars = "$2a$10$oXYO6/UvbsH5rQEraBkl6uheccBqdB3n.RaWbrimog9hS2GX4lo/O";
+		assertThat(encoder.matches(password72chars, encodedPassword72chars)).isTrue();
+
+		// Max length is 72 bytes, however, we need to ensure backwards compatibility
+		// for previously encoded passwords that are greater than 72 bytes and allow the
+		// match to be performed.
+		String password73chars = password72chars + "3";
+		String encodedPassword73chars = "$2a$10$1l9.kvQTsqNLiCYFqmKtQOHkp.BrgIrwsnTzWo9jdbQRbuBYQ/AVK";
+		assertThatIllegalArgumentException().isThrownBy(() -> encoder.matches(password73chars, encodedPassword73chars));
+	}
+
 }


### PR DESCRIPTION
This PR fixes a High vulnerability (CVE-2025-22228) by introducing a strict password length check of 72 characters, and maintaining backward compatibility
By allowing verification of previously stored overlength passwords without failure, forced resets and login issues for existing users are avoided.
Error messaging was enhanced to inform users that passwords beyond 72 characters cannot be securely hashed, encouraging safer password practices. 
Fix for CVE-2025-22234 timing attack mitigation was also added

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2025-22228                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | BCryptPasswordEncoder.matches(CharSequence,String) will incorrectly return true for passwords larger than 72 </br>characters as long as the first 72 characters are the same |
